### PR TITLE
Fix: changed data on ECSC 2022 event to be consistent with news page

### DIFF
--- a/events.html
+++ b/events.html
@@ -178,7 +178,7 @@
               <a href="/news/2022/04/06/ecsc2022.html"><img class="custom-thumbnail" src="/news/2022/04/06/logo_small.png" alt="" /></a>
           </div>
           <div class="lower-content" style="padding-bottom: 10px;">
-              <div class="post-date">Feb 20, 2020</div>
+              <div class="post-date">Apr 06, 2022</div>
               <h3><a href="/news/2022/04/06/ecsc2022.html">ECSC 2022 Qualifications</a></h3>
               <ul class="tags"  style="min-height: 100px;">
                      


### PR DESCRIPTION
I've noticed that the date was not consitent over the events page and the news page itself for the ecsc 2022 qualifiers.
[Event page 2020/02/20](https://letzpwn.com/events.html)
[News page 2022/04/06](https://letzpwn.com/news/2022/04/06/ecsc2022.html)

Hope this helps 😄 